### PR TITLE
Quote fields when accessed via the PDO adapter.

### DIFF
--- a/lib/Spot/Adapter/Mysql.php
+++ b/lib/Spot/Adapter/Mysql.php
@@ -68,6 +68,16 @@ class Mysql extends PDO_Abstract implements AdapterInterface
 		}
 		return $this->_engine;
 	}
+	
+	/**
+	 * Escape/quote direct user input
+	 *
+	 * @param string $string
+	 */
+	public function escapeField($field)
+	{
+		return $field == '*' ? $field : '`' . $field . '`';
+	}
 
 
 	/**


### PR DESCRIPTION
Unfortunately the PHPUnit appears to be having some issues so I was unable to pull it and update any tests if needed, but this patch adds escapeField to the PDO_Abstract class and extends the Mysql class to quote fields as `{field_name}` so you can use fields that may contain otherwise invalid characters or names.
