### PR TITLE
Fixing case issue with new Types

### DIFF
--- a/lib/Spot/Config.php
+++ b/lib/Spot/Config.php
@@ -26,8 +26,8 @@ class Config implements \Serializable
         $this->typeHandler('bool', '\Spot\Type\Boolean');
         $this->typeHandler('boolean', '\Spot\Type\Boolean');
 
-        $this->typeHandler('datetime', '\Spot\Type\DateTime');
-        $this->typeHandler('date', '\Spot\Type\DateTime');
+        $this->typeHandler('datetime', '\Spot\Type\Datetime');
+        $this->typeHandler('date', '\Spot\Type\Datetime');
         $this->typeHandler('timestamp', '\Spot\Type\Integer');
         $this->typeHandler('year', '\Spot\Type\Integer');
         $this->typeHandler('month', '\Spot\Type\Integer');


### PR DESCRIPTION
the Datetime type fails if you're using a case-sensitive file system, as the filename is 'Datetime' but the type being registered is 'DateTime'.  I elected to rename the type being registered, but you may prefer to rename the Datetime class and file.
