### PR TITLE
Fix some issues with setting null values to fields.

### DIFF
--- a/lib/Spot/Entity.php
+++ b/lib/Spot/Entity.php
@@ -278,9 +278,9 @@ abstract class Entity
     {
         $v = null;
 
-        if(isset($this->_dataModified[$field])) {
+        if(array_key_exists($field, $this->_dataModified)) {
             $v =  $this->_dataModified[$field];
-        } elseif(isset($this->_data[$field])) {
+        } elseif(array_key_exists($field, $this->_data)) {
             $v = $this->_data[$field];
         }
 

--- a/lib/Spot/Entity.php
+++ b/lib/Spot/Entity.php
@@ -120,7 +120,7 @@ abstract class Entity
             $fields = $this->fields();
             foreach($data as $k => $v) {
                 // Ensure value is set with type handler if Entity field type
-                if(isset($fields[$k])) {
+                if(array_key_exists($k, $fields)) {
                     $typeHandler = Config::typeHandler($fields[$k]['type']);
                     $v = $typeHandler::set($this, $v);
                 }
@@ -182,9 +182,13 @@ abstract class Entity
     public function isModified($field = null)
     {
         if (null !== $field) {
-            if (isset($this->_dataModified[$field])) {
+            if (array_key_exists($field, $this->_dataModified)) {
+                if (is_null($this->_dataModified[$field]) || is_null($this->_data[$field])) {
+                    // Use strict comparison for null values, non-strict otherwise
+                    return $this->_dataModified[$field] !== $this->_data[$field];
+                }
                 return $this->_dataModified[$field] != $this->_data[$field];
-            } else if (isset($this->_data[$field])) {
+            } else if (array_key_exists($field, $this->_data)) {
                 return false;
             } else {
                 return null;

--- a/tests/Test/Entity.php
+++ b/tests/Test/Entity.php
@@ -124,4 +124,42 @@ class Test_Entity extends PHPUnit_Framework_TestCase
 
         $this->assertNull($post->dataModified('status'));
     }
+
+
+    public function testDataNulls()
+    {
+        $data = array(
+            'title' => 'A Post',
+            'body' => 'A Body',
+            'status' => 0
+        );
+
+        $post = new Entity_Post($data);
+
+        $post->status = null;
+
+        $this->assertTrue($post->isModified('status'));
+
+        $post->status = 1;
+
+        $this->assertTrue($post->isModified('status'));
+
+        $post->data(array('status' => null));
+
+        $this->assertTrue($post->isModified('status'));
+
+        $post->title = '';
+
+        $this->assertTrue($post->isModified('title'));
+
+        $this->title = null;
+
+        $this->assertTrue($post->isModified('title'));
+
+        $this->title = 'A Post';
+
+        $post->data(array('title' => null));
+        
+        $this->assertTrue($post->isModified('title'));
+    }
 }


### PR DESCRIPTION
I've come across some further issues when dealing with nulls, both due to how `isset` handles null fields and with the fact that null is the same as 0 or an empty string with non-strict comparison.  There's one test in the test suite that will fail until my earlier fix for the Integer type-casting is merged as well.
