### PR TITLE
Adding support for travis-ci.org continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+# see http://about.travis-ci.org/docs/user/languages/php/ for more hints
+language: php
+
+# list any PHP version you want to test against
+php:
+  # using major version aliases
+  - 5.3.3
+  - 5.3                                
+  - 5.4
+
+services:
+  - mongodb
+  
+# optionally specify a list of environments, for example to test different RDBMS
+env:
+  - DB=mysql
+  - DB=mongo
+
+# execute any number of scripts before the test run, custom env's are available as variables
+before_script:
+  - if [[ "$DB" == "mongo" ]]; then 
+    pecl -q install mongo && echo "extension=mongo.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`;
+    fi
+  - if [[ "$DB" == "mysql" ]]; then mysql -e "create database IF NOT EXISTS spot_test;" -uroot; fi
+
+# omitting "script:" will default to phpunit
+# use the $DB env variable to determine the phpunit.xml to use
+script: phpunit --configuration phpunit_$DB.xml --coverage-text
+
+# configure notifications (email, IRC, campfire etc)
+#notifications:
+#  irc: "irc.freenode.org#travis"

--- a/phpunit_mongo.xml
+++ b/phpunit_mongo.xml
@@ -11,8 +11,8 @@
          bootstrap="./tests/init.php"
 >
     <php>
-        <var name="db_type" value="mongo" /> 
-        <var name="db_dsn" value="mongodb://localhost/test" />
+        <env name="db_type" value="mongo" /> 
+        <env name="db_dsn" value="mongodb://localhost/test" />
     </php>
 
   <testsuites>

--- a/phpunit_mongo.xml
+++ b/phpunit_mongo.xml
@@ -10,6 +10,11 @@
          syntaxCheck="false"
          bootstrap="./tests/init.php"
 >
+    <php>
+        <var name="db_type" value="mongo" /> 
+        <var name="db_dsn" value="mongodb://localhost/test" />
+    </php>
+
   <testsuites>
     <testsuite name="Spot">
       <directory suffix=".php">./tests/Test</directory>

--- a/phpunit_mysql.xml
+++ b/phpunit_mysql.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="./tests/init.php"
+>
+    <php>
+        <var name="db_type" value="mysql" />
+        <var name="db_dsn" value="mysql://root@localhost/spot_test" />
+    </php>
+
+  <testsuites>
+    <testsuite name="Spot">
+      <directory suffix=".php">./tests/Test</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/phpunit_mysql.xml
+++ b/phpunit_mysql.xml
@@ -11,8 +11,8 @@
          bootstrap="./tests/init.php"
 >
     <php>
-        <var name="db_type" value="mysql" />
-        <var name="db_dsn" value="mysql://root@localhost/spot_test" />
+        <env name="db_type" value="mysql" />
+        <env name="db_dsn" value="mysql://root@localhost/spot_test" />
     </php>
 
   <testsuites>

--- a/tests/init.php
+++ b/tests/init.php
@@ -13,14 +13,14 @@ date_default_timezone_set('America/Chicago');
 
 $cfg = new \Spot\Config();
           
-if ($GLOBALS['db_type'] == "mysql") {
+if ($_ENV['db_type'] == "mysql") {
     // MySQL
-    $cfg->addConnection('test', $GLOBALS['db_dsn']);
+    $cfg->addConnection('test', $_ENV['db_dsn']);
 }
 elseif ($GLOBALS['db_type'] == "mongo")
 {
     // MongoDB with adapter options
-    $cfg->addConnection('test_mongodb', $GLOBALS['db_dsn'], array(
+    $cfg->addConnection('test_mongodb', $_ENV['db_dsn'], array(
         'cursor' => array(
             'timeout' => 10
         ),

--- a/tests/init.php
+++ b/tests/init.php
@@ -1,7 +1,7 @@
--<?php
+<?php
 /**
- * @package Spot
- */
+* @package Spot
+*/
 
 // Require Spot_Config
 require_once dirname(__DIR__) . '/lib/Spot/Config.php';
@@ -12,22 +12,32 @@ date_default_timezone_set('America/Chicago');
 // Setup available adapters for testing
 
 $cfg = new \Spot\Config();
-// MySQL
-$adapter = $cfg->addConnection('test_mysql', 'mysql://test:password@localhost/spot_test');
-// MongoDB with adapter options
-$adapter = $cfg->addConnection('test_mongodb', 'mongodb://localhost:28017', array(
-    'cursor' => array(
-        'timeout' => 10
-    ),
-    'mapper' => array(
-        'translate_id' => true
-	)
-));
-
+          
+if ($GLOBALS['db_type'] == "mysql") {
+    // MySQL
+    $cfg->addConnection('test', $GLOBALS['db_dsn']);
+}
+elseif ($GLOBALS['db_type'] == "mongo")
+{
+    // MongoDB with adapter options
+    $cfg->addConnection('test_mongodb', $GLOBALS['db_dsn'], array(
+        'cursor' => array(
+            'timeout' => 10
+        ),
+        'mapper' => array(
+            'translate_id' => true
+        )
+    ));
+}
+else
+{
+    // Db Type hasn't been configured
+    exit(1);
+}
 
 /**
- * Return Spot mapper for use
- */
+* Return Spot mapper for use
+*/
 $mapper = new \Spot\Mapper($cfg);
 function test_spot_mapper() {
     global $mapper;
@@ -36,8 +46,8 @@ function test_spot_mapper() {
 
 
 /**
- * Autoload test fixtures
- */
+* Autoload test fixtures
+*/
 function test_spot_autoloader($className) {
     // Only autoload classes that start with "Test_" and "Entity_"
     if(false === strpos($className, 'Test_') && false === strpos($className, 'Entity_')) {


### PR DESCRIPTION
Travis-CI.org is a continuous integration site that connects with GitHub and will automatically run your tests on specified configurations every time you push to github. Before this, the mongo connection was never being tested, now mysql and mongo are each tested separately on php version 5.3, 5.3.3, and 5.4. 

You can see what this looks like here: https://travis-ci.org/TheSavior/Spot

Travis-CI will also run these tests on pull requests once it is set up on the base repo.

Setting min version to 5.3 because we require namespaces.
Splitting Mongo Settings out into seperate run.
Adding failure if run with a db that hasn't been configured
