### PR TITLE
Event system

### DIFF
--- a/lib/Spot/Entity.php
+++ b/lib/Spot/Entity.php
@@ -97,6 +97,15 @@ abstract class Entity
 
 
     /**
+     * Return defined hooks of the entity
+     */
+    public static function hooks()
+    {
+        return array();
+    }
+
+
+    /**
      * Return defined fields of the entity
      */
     public static function relations()

--- a/lib/Spot/Mapper.php
+++ b/lib/Spot/Mapper.php
@@ -818,9 +818,11 @@ class Mapper
 
     public function on($entityName, $hook, $callable)
     {
-        if (is_callable($callable)) {
-            $this->_hooks[$entityName][$hook][] = $callable;
+        if (!is_callable($callable)) {
+            throw new \InvalidArgumentException(__METHOD__ . " for {$entityName}->{$hook} requires a valid callable, given " . gettype($callable) . "");
         }
+        $this->_hooks[$entityName][$hook][] = $callable;
+        return $this;
     }
 
     public function off($entityName, $hooks, $callable = null)
@@ -840,6 +842,7 @@ class Mapper
                 }
             }
         }
+        return $this;
     }
 
     public function getHooks($entityName, $hook)

--- a/lib/Spot/Mapper.php
+++ b/lib/Spot/Mapper.php
@@ -818,24 +818,19 @@ class Mapper
 
     public function on($entityName, $hook, $callable)
     {
-        if (!isset($this->_hooks[$entityName])) {
-            $this->_hooks[$entityName] = array();
+        if (is_callable($callable)) {
+            $this->_hooks[$entityName][$hook][] = $callable;
         }
-        if (!isset($this->_hooks[$entityName][$hook])) {
-            $this->_hooks[$entityName][$hook] = array();
-        }
-        $this->_hooks[$entityName][$hook][] = $callable;
     }
 
-    public function off($entityName, $hook, $callable = null)
+    public function off($entityName, $hooks, $callable = null)
     {
-        $hooks = is_array($hook) ? $hook : array($hook);
         if (isset($this->_hooks[$entityName])) {
-            foreach ($hooks as $hook) {
+            foreach ((array)$hooks as $hook) {
                 if (true === $hook) {
                     unset($this->_hooks[$entityName]);
-                } if (isset($this->_hooks[$entityName][$hook])) {
-                    if ($callable) {
+                } else if (isset($this->_hooks[$entityName][$hook])) {
+                    if (null !== $callable) {
                         if ($key = array_search($this->_hooks[$entityName][$hook], $callable, true)) {
                             unset($this->_hooks[$entityName][$hook][$key]);
                         }

--- a/tests/Entity/Post.php
+++ b/tests/Entity/Post.php
@@ -7,6 +7,8 @@
 class Entity_Post extends \Spot\Entity
 {
     protected static $_datasource = 'test_posts';
+    // For testing purposes only
+    public static $hooks = array();
 
     public static function fields()
     {
@@ -46,5 +48,15 @@ class Entity_Post extends \Spot\Entity
                 'where' => array('id' => ':entity.author_id')
             ),
         );
+    }
+
+    public static function hooks()
+    {
+        return static::$hooks;
+    }
+    
+    public function mock_save_hook()
+    {
+        $this->status++;
     }
 }

--- a/tests/Test/Hooks.php
+++ b/tests/Test/Hooks.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * @package Spot
- * @link http://spot.os.ly
  */
 class Test_Hooks extends PHPUnit_Framework_TestCase
 {
@@ -33,7 +32,7 @@ class Test_Hooks extends PHPUnit_Framework_TestCase
                 'title' => ($i % 2 ? 'odd' : 'even' ). '_title',
                 'body' => '<p>' . $i  . '_body</p>',
                 'status' => $i ,
-                'date_created' => $mapper->connection('Entity_Post')->dateTime(),
+                'date_created' => new \DateTime(),
                 'author_id' => rand(1,3)
             ));
             for( $j = 1; $j <= 2; $j++ ) {
@@ -56,6 +55,17 @@ class Test_Hooks extends PHPUnit_Framework_TestCase
     {
         $mapper = test_spot_mapper();
         $mapper->off('Entity_Post', true);
+    }
+
+    public function testInvalidHooks()
+    {
+        $mapper = test_spot_mapper();
+        $testcase = $this;
+        
+        $mapper->on('Entity_Post', 'beforeSave', 'asdf');
+        $mapper->on('Entity_Post', 'beforeSave', array($this, 'garbage'));
+        
+        $this->assertEquals(array(), $mapper->getHooks('Entity_Post', 'beforeSave'));
     }
 
     public function testSaveHooks()

--- a/tests/Test/Hooks.php
+++ b/tests/Test/Hooks.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * @package Spot
+ * @link http://spot.os.ly
+ */
+class Test_Hooks extends PHPUnit_Framework_TestCase
+{
+    protected $backupGlobals = false;
+
+    protected function tearDown()
+    {
+        $mapper = test_spot_mapper();
+        $mapper->off('Entity_Post', true);
+    }
+
+    public function testSaveHooks()
+    {
+        $mapper = test_spot_mapper();
+        $testcase = $this;
+
+        $post = new Entity_Post(array(
+            'title' => 'A title',
+            'body' => '<p>body</p>',
+            'status' => 1,
+            'author_id' => 1,
+            'date_created' => new \DateTime()
+        ));
+
+        $hooks = array();
+
+        $mapper->on('Entity_Post', 'beforeSave', function($post, $mapper) use (&$hooks, $testcase) {
+            $testcase->assertEquals($hooks, array());
+            $hooks[] = 'called beforeSave';
+        });
+
+        $mapper->on('Entity_Post', 'afterSave', function($post, $mapper, $result) use (&$hooks, $testcase) {
+            $testcase->assertEquals($hooks, array('called beforeSave'));
+            $testcase->assertInstanceOf('Entity_Post', $post);
+            $testcase->assertInstanceOf('\\Spot\\Mapper', $mapper);
+            $hooks[] = 'called afterSave';
+        });
+
+        $this->assertEquals($hooks, array());
+
+        $mapper->save($post);
+
+        $this->assertEquals($hooks, array('called beforeSave', 'called afterSave'));
+
+        $mapper->off('Entity_Post', array('afterSave', 'beforeSave'));
+
+        $mapper->save($post);
+
+        // Verify that hooks were deregistered
+        $this->assertEquals($hooks, array('called beforeSave', 'called afterSave'));
+    }
+
+    public function testInsertHooks()
+    {
+        $mapper = test_spot_mapper();
+        $testcase = $this;
+
+        $post = new Entity_Post(array(
+            'title' => 'A title',
+            'body' => '<p>body</p>',
+            'status' => 1,
+            'author_id' => 1,
+            'date_created' => new \DateTime()
+        ));
+
+        $hooks = array();
+        
+        $mapper->on('Entity_Post', 'beforeInsert', function($post, $mapper) use (&$hooks, $testcase) {
+            $testcase->assertEquals($hooks, array());
+            $hooks[] = 'called beforeInsert';
+        });
+
+        $mapper->on('Entity_Post', 'afterInsert', function($post, $mapper, $result) use (&$hooks, $testcase) {
+            $testcase->assertEquals($hooks, array('called beforeInsert'));
+            $hooks[] = 'called afterInsert';
+        });
+
+        $this->assertEquals($hooks, array());
+
+        $mapper->save($post);
+
+        $this->assertEquals($hooks, array('called beforeInsert', 'called afterInsert'));
+    }
+
+    public function testUpdateHooks()
+    {
+        $mapper = test_spot_mapper();
+        $testcase = $this;
+
+        $post = new Entity_Post(array(
+            'title' => 'A title',
+            'body' => '<p>body</p>',
+            'status' => 1,
+            'author_id' => 1,
+            'date_created' => new \DateTime()
+        ));
+        $mapper->save($post);
+
+        $hooks = array();
+
+        $mapper->on('Entity_Post', 'beforeInsert', function($post, $mapper) use ($testcase) {
+            $testcase->assertTrue(false);
+        });
+
+        $mapper->on('Entity_Post', 'beforeUpdate', function($post, $mapper) use (&$hooks, $testcase) {
+            $testcase->assertEquals($hooks, array());
+            $hooks[] = 'called beforeUpdate';
+        });
+
+        $mapper->on('Entity_Post', 'afterUpdate', function($post, $mapper, $result) use (&$hooks, $testcase) {
+            $testcase->assertEquals($hooks, array('called beforeUpdate'));
+            $hooks[] = 'called afterUpdate';
+        });
+
+        $this->assertEquals($hooks, array());
+
+        $mapper->save($post);
+
+        $this->assertEquals($hooks, array('called beforeUpdate', 'called afterUpdate'));
+    }
+
+
+    public function testDeleteHooks()
+    {
+        $mapper = test_spot_mapper();
+        $testcase = $this;
+
+        $post = new Entity_Post(array(
+            'title' => 'A title',
+            'body' => '<p>body</p>',
+            'status' => 1,
+            'author_id' => 1,
+            'date_created' => new \DateTime()
+        ));
+        $mapper->save($post);
+
+        $hooks = array();
+
+        $mapper->on('Entity_Post', 'beforeDelete', function($post, $mapper) use (&$hooks, $testcase) {
+            $testcase->assertEquals($hooks, array());
+            $hooks[] = 'called beforeDelete';
+        });
+
+        $mapper->on('Entity_Post', 'afterDelete', function($post, $mapper, $result) use (&$hooks, $testcase) {
+            $testcase->assertEquals($hooks, array('called beforeDelete'));
+            $hooks[] = 'called afterDelete';
+        });
+
+        $this->assertEquals($hooks, array());
+
+        $mapper->delete($post);
+
+        $this->assertEquals($hooks, array('called beforeDelete', 'called afterDelete'));
+    }
+
+
+    public function testHookReturnsFalse()
+    {
+        $mapper = test_spot_mapper();
+        $post = new Entity_Post(array(
+            'title' => 'A title',
+            'body' => '<p>body</p>',
+            'status' => 1,
+            'author_id' => 1,
+            'date_created' => new \DateTime()
+        ));
+
+        $hooks = array();
+
+        $mapper->on('Entity_Post', 'beforeSave', function($post, $mapper) use (&$hooks) {
+            $hooks[] = 'called beforeSave';
+            return false;
+        });
+
+        $mapper->on('Entity_Post', 'afterSave', function($post, $mapper, $result) use (&$hooks) {
+            $hooks[] = 'called afterSave';
+        });
+
+        $mapper->save($post);
+
+        $mapper->off('Entity_Post', array('beforeSave', 'afterSave'));
+
+        $this->assertEquals($hooks, array('called beforeSave'));
+    }
+}


### PR DESCRIPTION
Right now we have the hardcoded `beforeSave()`, `afterSave()`, etc. methods.  I'm wondering what your thoughts are on having a lightweight event system - so in your `Entity`s constructor you would do something like:

``` php
$this->before('save', 'name_of_a_method');
$this->before('delete', function($mapper) { // A callable });
$this->after('loadCollection', array('Static_object', 'static_method'));
```
