### PR TITLE
Fix #57 - After foreach on result set resets conditions in query

### DIFF
--- a/lib/Spot/Query.php
+++ b/lib/Spot/Query.php
@@ -418,7 +418,6 @@ class Query implements \Countable, \IteratorAggregate, QueryInterface
     {
         // Execute query and return result set for iteration
         $result = $this->execute();
-        $this->reset();
         return ($result !== false) ? $result : array();
     }
 

--- a/tests/Test/Query.php
+++ b/tests/Test/Query.php
@@ -240,7 +240,7 @@ class Test_Query extends PHPUnit_Framework_TestCase
         $this->assertEquals(10, $posts->count());
     }
 
-  public function testQueryAutomaticReset()
+  public function testQueryNoResetAfterForeach()
   {
         $mapper = test_spot_mapper();
         $posts = $mapper->all('Entity_Post');
@@ -249,9 +249,9 @@ class Test_Query extends PHPUnit_Framework_TestCase
         $posts->where(array('title' => 'odd_title'));
         $this->assertNotEquals(10, $posts->count());
         foreach ($posts as $post) {}
-
-        $this->assertEquals($posts->conditions, array());
-        $this->assertEquals(10, $posts->count());
+        
+        $this->assertCount(1, $posts->conditions);
+        $this->assertNotEquals(10, $posts->count());
     }
 
     public function testQuerySnapshot()


### PR DESCRIPTION
Current code causes incorrect behaviour when wanting to use the result set after a foreach loop, this fix removes the automatic call to reset to stop this
