### PR TITLE
Remove require of autoload from config and add into phpunit test init script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 composer.phar
+composer.lock
 vendor

--- a/lib/Spot/Config.php
+++ b/lib/Spot/Config.php
@@ -138,16 +138,3 @@ class Config implements \Serializable
     {
     }
 }
-
-/**
- * Path trickery designed to find composer autoloader and require
- */
-$vendorPos = strpos(__DIR__, 'vendor/vlucas/spot');
-if($vendorPos !== false) {
-  // Package has been cloned within another composer package, resolve path to autoloader
-  $vendorDir = substr(__DIR__, 0, $vendorPos) . 'vendor/';
-  $loader = require $vendorDir . 'autoload.php';
-} else {
-  // Package itself (cloned standalone)
-  $loader = require __DIR__.'/../../vendor/autoload.php';
-}

--- a/tests/init.php
+++ b/tests/init.php
@@ -6,8 +6,7 @@
 error_reporting(-1);
 ini_set('display_errors', 1);
 
-// Require Spot_Config
-require_once dirname(__DIR__) . '/lib/Spot/Config.php';
+require dirname(dirname(__FILE__)) . '/vendor/autoload.php';
 
 // Date setup
 date_default_timezone_set('America/Chicago');
@@ -32,7 +31,6 @@ function test_spot_mapper() {
     global $mapper;
     return $mapper;
 }
-
 
 /**
 * Autoload test fixtures


### PR DESCRIPTION
Remove require of autoload from config.php and stuck it in the phpunit init.php to load Spot classes solely for unit testing only. Composer should autoload the Spot files otherwise. 

-Also Added ignore of composer.lock
