### PR TITLE
Update type system to get types from Type classes

### DIFF
--- a/lib/Spot/Adapter/AdapterInterface.php
+++ b/lib/Spot/Adapter/AdapterInterface.php
@@ -3,9 +3,8 @@ namespace Spot\Adapter;
 
 /**
  * Adapter Interface
- * 
+ *
  * @package Spot
- * @link http://spot.os.ly
  */
 interface AdapterInterface
 {
@@ -15,126 +14,107 @@ interface AdapterInterface
     * @return void
     */
     public function __construct($dsn, array $options = array());
-    
-    
+
     /**
      * Get database connection
      */
     public function connection();
-    
-    
+
     /**
      * Get database DATE format for PHP date() function
      */
     public function dateFormat();
-    
-    
+
     /**
      * Get database TIME format for PHP date() function
      */
     public function timeFormat();
-    
-    
+
     /**
      * Get database full DATETIME for PHP date() function
      */
     public function dateTimeFormat();
-    
-    
+
     /**
      * Get date in format that adapter understands for queries
      */
     public function date($format = null);
-    
-    
+
     /**
      * Get time in format that adapter understands for queries
      */
     public function time($format = null);
-    
-    
+
     /**
      * Get datetime in format that adapter understands for queries
      */
     public function dateTime($format = null);
-    
-    
+
     /**
      * Escape/quote direct user input
      *
      * @param string $string
      */
     public function escape($string);
-    
-    
+
     /**
      * Insert entity
      */
     public function create($source, array $data, array $options = array());
-    
-    
+
     /**
      * Read from data source using given query object
      */
     public function read(\Spot\Query $query, array $options = array());
-    
-    
+
     /*
      * Count number of rows in source based on conditions
      */
     public function count(\Spot\Query $query, array $options = array());
-    
-    
+
     /**
      * Update entity
      */
     public function update($source, array $data, array $where = array(), array $options = array());
-    
-    
+
     /**
      * Delete entity
      */
     public function delete($source, array $where, array $options = array());
-    
-    
+
     /**
      * Begin transaction
      */
     public function beginTransaction();
-    
-    
+
     /**
      * Commit transaction
      */
     public function commit();
-    
-    
+
     /**
      * Rollback transaction
      */
     public function rollback();
-    
 
     /**
      * Truncate data source (table for SQL)
      * Should delete all rows and reset serial/auto_increment keys to 0
      */
     public function truncateDatasource($source);
-    
+
     /**
      * Drop/delete data source (table for SQL)
      * Destructive and dangerous - drops entire data source and all data
      */
     public function dropDatasource($source);
-    
-    
+
     /**
      * Create a database
       * Will throw errors if user does not have proper permissions
      */
     public function createDatabase($database);
-    
-    
+
     /**
      * Drop an entire database
      * Destructive and dangerous - drops entire table and all data
@@ -142,3 +122,4 @@ interface AdapterInterface
      */
     public function dropDatabase($database);
 }
+

--- a/lib/Spot/Adapter/PDO/BaseAbstract.php
+++ b/lib/Spot/Adapter/PDO/BaseAbstract.php
@@ -1,6 +1,5 @@
 <?php
 namespace Spot\Adapter\PDO;
-
 use Spot\Adapter;
 
 /**
@@ -11,7 +10,6 @@ use Spot\Adapter;
 abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\AdapterInterface
 {
     protected $_database;
-
 
     /**
      * Get database connection
@@ -41,7 +39,6 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
         return $this->_connection;
     }
 
-
     /**
      * Escape/quote direct user input
      *
@@ -62,7 +59,6 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
         return $field;
     }
 
-
     /**
      * Ensure migration options are full and have all keys required
      */
@@ -70,7 +66,6 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
     {
         return $options;
     }
-
 
     /**
      * Migrate table structure changes to database
@@ -103,10 +98,9 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
         }
     }
 
-
     /**
      * Execute a CREATE TABLE command
-     * 
+     *
      * @param String $table Table name
      * @param Array $fields Fields and their attributes as defined in the mapper
      * @param Array $options Options that may affect migrations or how tables are setup
@@ -135,7 +129,6 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
         $this->connection()->exec($sql);
         return true;
     }
-
 
     /**
      * Execute an ALTER/UPDATE TABLE command
@@ -199,7 +192,7 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
         }
         return true;
     }
-    
+
     /**
      * Should we update the field
      *
@@ -214,13 +207,12 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
     }
 
     /**
-     * Prepare an SQL statement 
+     * Prepare an SQL statement
      */
     public function prepare($sql)
     {
         return $this->connection()->prepare($sql);
     }
-
 
     /**
      * Find records with custom SQL query
@@ -247,7 +239,6 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
             throw new \Spot\Exception(__METHOD__ . " Error: Unable to execute SQL query - failed to create prepared statement from given SQL");
         }
     }
-
 
     /**
      * Create new row object with set properties
@@ -291,7 +282,6 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
 
         return $result;
     }
-
 
     /**
      * Build a select statement in SQL
@@ -471,7 +461,6 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
         return $result;
     }
 
-
     /**
      * Delete entities matching given conditions
      *
@@ -512,7 +501,6 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
         }
     }
 
-
     /**
      * Begin transaction
      */
@@ -524,7 +512,6 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
 
         return $this->connection()->exec($sql);
     }
-
 
     /**
      * Commit transaction
@@ -538,7 +525,6 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
         return $this->connection()->exec($sql);
     }
 
-
     /**
      * Rollback transaction
      */
@@ -550,7 +536,6 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
 
         return $this->connection()->exec($sql);
     }
-
 
     /**
      * Truncate a database table
@@ -575,7 +560,6 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
         }
     }
 
-
     /**
      * Drop a database table
      * Destructive and dangerous - drops entire table and all data
@@ -599,7 +583,6 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
         }
     }
 
-
     /**
      * Create a database
      * Will throw errors if user does not have proper permissions
@@ -612,7 +595,6 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
 
         return $this->connection()->exec($sql);
     }
-
 
     /**
      * Drop a database table
@@ -627,7 +609,6 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
 
         return $this->connection()->exec($sql);
     }
-
 
     /**
      * Return fields as a string for a query statement
@@ -646,7 +627,6 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
         }
         return count($fields) > 0 ? implode(', ', $preparedFields) : "*";
     }
-
 
     /**
      * Builds an SQL string given conditions
@@ -782,7 +762,6 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
         return $sqlStatement;
     }
 
-
     /**
      * Returns array of binds to pass to query function
      */
@@ -847,7 +826,6 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
         return $binds;
     }
 
-
     /**
      * Return result set for current query
      */
@@ -873,7 +851,6 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
         }
     }
 
-
     /**
      * Bind array of field/value data to given statement
      *
@@ -889,3 +866,4 @@ abstract class BaseAbstract extends Adapter\AdapterAbstract implements Adapter\A
         return true;
     }
 }
+

--- a/lib/Spot/Adapter/Sqlite.php
+++ b/lib/Spot/Adapter/Sqlite.php
@@ -22,30 +22,9 @@ class Sqlite extends PDO\BaseAbstract implements AdapterInterface
     // Map datamapper field types to actual database adapter types
     // @todo Have to improve this to allow custom types, callbacks, and validation
     protected $_fieldTypeMap = array(
-        'string' => array(
-            'adapter_type' => 'varchar',
-            'length' => 255
-            ),
-        'email' => array(
-            'adapter_type' => 'varchar',
-            'length' => 255
-            ),
-        'url' => array(
-            'adapter_type' => 'varchar',
-            'length' => 255
-            ),
-        'tel' => array(
-            'adapter_type' => 'varchar',
-            'length' => 255
-            ),
-        'password' => array(
-            'adapter_type' => 'varchar',
-            'length' => 255
-            ),
+        'string' => array('adapter_type' => 'varchar', 'length' => 255),
         'text' => array('adapter_type' => 'text'),
-        'int' => array('adapter_type' => 'int'),
         'integer' => array('adapter_type' => 'int'),
-        'bool' => array('adapter_type' => 'tinyint', 'length' => 1),
         'boolean' => array('adapter_type' => 'tinyint', 'length' => 1),
         'float' => array('adapter_type' => 'float'),
         'double' => array('adapter_type' => 'double'),
@@ -125,7 +104,7 @@ class Sqlite extends PDO\BaseAbstract implements AdapterInterface
 
         return false;
     }
-    
+
     /**
      * Truncate a database table
      * Should delete all rows and reset serial/auto_increment keys to 0
@@ -148,7 +127,7 @@ class Sqlite extends PDO\BaseAbstract implements AdapterInterface
             throw $e;
         }
     }
-    
+
     /**
      * Migrate table structure changes to database
      * @param String $table Table name
@@ -164,11 +143,11 @@ class Sqlite extends PDO\BaseAbstract implements AdapterInterface
         if($tableColumns) {
             $tableExists = true;
         }
-        
+
         if ($tableExists) {
             $this->dropDatasource($table);
-        } 
-        
+        }
+
         // Create table
         $this->migrateTableCreate($table, $fields, $options);
     }
@@ -191,16 +170,16 @@ class Sqlite extends PDO\BaseAbstract implements AdapterInterface
 
         $fieldInfo = array_merge($this->_fieldTypeMap[$fieldInfo['type']],$fieldInfo);
 
-        $syntax = $fieldName . ' '; 
+        $syntax = $fieldName . ' ';
 
         if ($fieldInfo['primary']) {
             $syntax .= ' INTEGER PRIMARY KEY AUTOINCREMENT';
         } else {
             $syntax .= (($fieldInfo['unsigned']) ? 'unsigned ' : '') . $fieldInfo['adapter_type'];
-    
+
             // Column type and length
             $syntax .= ($fieldInfo['length']) ? '(' . $fieldInfo['length'] . ')' : '';
-            
+
             // Nullable
             $isNullable = true;
             if ($fieldInfo['required'] || !$fieldInfo['null']) {
@@ -216,7 +195,7 @@ class Sqlite extends PDO\BaseAbstract implements AdapterInterface
                 if ( is_bool($default) && $fieldInfo['type'] == "boolean" ) {
                     $default = $default ? 1 : 0;
                 }
-    
+
                 if (is_scalar($default)) {
                     $syntax .= " DEFAULT '" . $default . "'";
                 }
@@ -241,15 +220,15 @@ class Sqlite extends PDO\BaseAbstract implements AdapterInterface
         $syntax = "CREATE TABLE IF NOT EXISTS `" . $table . "` (\n";
         // Columns
         $syntax .= implode(",\n", $columnsSyntax);
-        
+
         // Keys...
         $tableKeys = array('unique' => array(),);
-        
+
         $usedKeyNames = array();
-        
+
         foreach ($formattedFields as $fieldName => $fieldInfo) {
-            
-            
+
+
             // Determine key field name (can't use same key name twice, so we have to append a number)
             $fieldKeyName = $fieldName;
             while(in_array($fieldKeyName, $usedKeyNames)) {
@@ -265,7 +244,7 @@ class Sqlite extends PDO\BaseAbstract implements AdapterInterface
                 $usedKeyNames[] = $fieldKeyName;
             }
         }
-        
+
         // UNIQUE
         foreach($tableKeys['unique'] as $keyName => $keyFields) {
             $syntax .= "\n, UNIQUE(" . implode(', ', $keyFields) . ")";

--- a/lib/Spot/Config.php
+++ b/lib/Spot/Config.php
@@ -14,7 +14,7 @@ class Config implements \Serializable
     {
         // Setup default type hanlders
         self::typeHandler('string', '\Spot\Type\String');
-        self::typeHandler('text', '\Spot\Type\String');
+        self::typeHandler('text', '\Spot\Type\Text');
 
         self::typeHandler('int', '\Spot\Type\Integer');
         self::typeHandler('integer', '\Spot\Type\Integer');

--- a/lib/Spot/Entity/Manager.php
+++ b/lib/Spot/Entity/Manager.php
@@ -1,5 +1,6 @@
 <?php
 namespace Spot\Entity;
+use Spot\Config;
 use Spot;
 
 /**
@@ -21,7 +22,6 @@ class Manager
     protected static $_connection = array();
     protected static $_datasource = array();
     protected static $_datasourceOptions = array();
-
 
     /**
      * Get formatted fields with all neccesary array keys and values.
@@ -74,24 +74,22 @@ class Manager
                 'primary' => false,
                 'index' => false,
                 'unique' => false,
-                'serial' => false,
-
-                'relation' => false
-                );
+                'serial' => false
+            );
 
             // Type default overrides for specific field types
             $fieldTypeDefaults = array(
                 'string' => array(
                     'length' => 255
-                    ),
+                ),
                 'float' => array(
                     'length' => array(10,2)
-                    ),
+                ),
                 'int' => array(
                     'length' => 10,
                     'unsigned' => true
-                    )
-                );
+                )
+            );
 
             // Get entity fields from entity class
             $entityFields = false;
@@ -116,6 +114,12 @@ class Manager
                     // Merge with defaults
                     $fieldOpts = array_merge($fieldDefaults, $fieldOpts);
                 }
+
+                // Get adapter options and type from typeHandler
+                $typeHandler = Config::typeHandler($fieldOpts['type']);
+                $typeOptions = $typeHandler::adapterOptions();
+                // Use typeOptions as base, merge field options, but keep 'type' from typeOptions
+                $fieldOpts = array_merge($typeOptions, $fieldOpts, array('type' => $typeOptions['type']));
 
                 // Store primary key
                 if(true === $fieldOpts['primary']) {
@@ -145,7 +149,6 @@ class Manager
         return $returnFields;
     }
 
-
     /**
      * Get field information exactly how it is defined in the class
      *
@@ -159,7 +162,6 @@ class Manager
         }
         return self::$_fieldsDefined[$entityName];
     }
-
 
     /**
      * Get field default values as defined in class field definitons
@@ -175,7 +177,6 @@ class Manager
         return self::$_fieldDefaultValues[$entityName];
     }
 
-
     /**
      * Get defined relations
      *
@@ -190,7 +191,6 @@ class Manager
         return self::$_relations[$entityName];
     }
 
-
     /**
      * Get value of primary key for given row result
      *
@@ -204,7 +204,6 @@ class Manager
         return self::$_primaryKeyField[$entityName];
     }
 
-
     /**
      * Check if field exists in defined fields
      *
@@ -215,7 +214,6 @@ class Manager
     {
         return array_key_exists($field, $this->fields($entityName));
     }
-
 
     /**
      * Return field type
@@ -229,7 +227,6 @@ class Manager
         $fields = $this->fields($entityName);
         return $this->fieldExists($entityName, $field) ? $fields[$field]['type'] : false;
     }
-
 
     /**
      * Get defined connection to use for entity
@@ -245,7 +242,6 @@ class Manager
         return self::$_connection[$entityName];
     }
 
-
     /**
      * Get name of datasource for given entity class
      *
@@ -259,7 +255,6 @@ class Manager
         }
         return self::$_datasource[$entityName];
     }
-
 
     /**
      * Get datasource options for given entity class
@@ -275,3 +270,4 @@ class Manager
         return self::$_datasourceOptions[$entityName];
     }
 }
+

--- a/lib/Spot/Entity/Manager.php
+++ b/lib/Spot/Entity/Manager.php
@@ -11,7 +11,6 @@ use Spot;
 class Manager
 {
     // Field and relation info
-    protected static $_properties = array();
     protected static $_fields = array();
     protected static $_fieldsDefined = array();
     protected static $_fieldDefaultValues = array();
@@ -175,6 +174,15 @@ class Manager
             $this->fields($entityName);
         }
         return self::$_fieldDefaultValues[$entityName];
+    }
+
+    public function resetFields()
+    {
+        self::$_fields = array();
+        self::$_fieldsDefined = array();
+        self::$_fieldDefaultValues = array();
+        self::$_relations = array();
+        self::$_primaryKeyField = array();
     }
 
     /**

--- a/lib/Spot/Type.php
+++ b/lib/Spot/Type.php
@@ -6,8 +6,8 @@ class Type implements Type\TypeInterface
 {
     public static $_loadHandlers = array();
     public static $_dumpHandlers = array();
-    public static $_defaultType = 'string';
-    public static $_defaultOptions = array();
+    public static $_adapterType = 'string';
+    public static $_adapterOptions = array();
 
 
     /**
@@ -68,5 +68,16 @@ class Type implements Type\TypeInterface
      */
     public static function dump($value) {
         return static::cast($value);
+    }
+
+    /**
+     * Array of adapter options with type
+     *
+     * @return array
+     */
+    public static function adapterOptions() {
+      return array_merge(static::$_adapterOptions, array(
+          'type' => static::$_adapterType
+      ));
     }
 }

--- a/lib/Spot/Type/Boolean.php
+++ b/lib/Spot/Type/Boolean.php
@@ -4,7 +4,7 @@ use Spot\Entity;
 
 class Boolean extends \Spot\Type
 {
-    public static $_defaultType = 'boolean';
+    public static $_adapterType = 'boolean';
 
     /**
      * Cast given value to type required

--- a/lib/Spot/Type/Date.php
+++ b/lib/Spot/Type/Date.php
@@ -4,6 +4,6 @@ use Spot\Entity;
 
 class Date extends DateTime
 {
-    public static $_defaultType = 'date';
+    public static $_adapterType = 'date';
     public static $_format = 'Y-m-d';
 }

--- a/lib/Spot/Type/Datetime.php
+++ b/lib/Spot/Type/Datetime.php
@@ -4,7 +4,7 @@ use Spot\Entity;
 
 class Datetime extends \Spot\Type
 {
-    public static $_defaultType = 'datetime';
+    public static $_adapterType = 'datetime';
     public static $_format = 'Y-m-d H:i:s';
 
     /**

--- a/lib/Spot/Type/Float.php
+++ b/lib/Spot/Type/Float.php
@@ -4,8 +4,8 @@ use Spot\Entity;
 
 class Float extends \Spot\Type
 {
-    public static $_defaultType = 'decimal';
-    public static $_defaultOptions = array('precision' => 14, 'scale' => 10);
+    public static $_adapterType = 'decimal';
+    public static $_adapterOptions = array('precision' => 14, 'scale' => 10);
 
     /**
      * Cast given value to type required

--- a/lib/Spot/Type/Integer.php
+++ b/lib/Spot/Type/Integer.php
@@ -4,7 +4,7 @@ use Spot\Entity;
 
 class Integer extends \Spot\Type
 {
-    public static $_defaultType = 'integer';
+    public static $_adapterType = 'integer';
 
     /**
      * Cast given value to type required

--- a/lib/Spot/Type/Noop.php
+++ b/lib/Spot/Type/Noop.php
@@ -1,7 +1,0 @@
-<?php
-namespace Spot\Type;
-use Spot\Entity;
-
-class Noop extends \Spot\Type
-{
-}

--- a/lib/Spot/Type/Serialized.php
+++ b/lib/Spot/Type/Serialized.php
@@ -4,7 +4,7 @@ use Spot\Entity;
 
 class Serialized extends \Spot\Type
 {
-    public static $_defaultType = 'serialized';
+    public static $_adapterType = 'text';
 
     /**
      * Cast given value to type required

--- a/lib/Spot/Type/String.php
+++ b/lib/Spot/Type/String.php
@@ -4,8 +4,6 @@ use Spot\Entity;
 
 class String extends \Spot\Type
 {
-    public static $_defaultType = 'string';
-
     /**
      * Cast given value to type required
      */

--- a/lib/Spot/Type/Text.php
+++ b/lib/Spot/Type/Text.php
@@ -1,0 +1,8 @@
+<?php
+namespace Spot\Type;
+use Spot\Type\String;
+
+class Text extends String
+{
+    public static $_adapterType = 'text';
+}

--- a/lib/Spot/Type/Time.php
+++ b/lib/Spot/Type/Time.php
@@ -4,6 +4,6 @@ use Spot\Entity;
 
 class Time extends DateTime
 {
-    public static $_defaultType = 'time';
+    public static $_adapterType = 'time';
     public static $_format = 'H:i:s';
 }

--- a/lib/Spot/Type/TypeInterface.php
+++ b/lib/Spot/Type/TypeInterface.php
@@ -11,4 +11,6 @@ interface TypeInterface
     public static function dump($value);
     public static function _load($value);
     public static function load($value);
+    public static function adapterOptions();
 }
+

--- a/tests/Entity/Type.php
+++ b/tests/Entity/Type.php
@@ -9,13 +9,16 @@ class Entity_Type extends \Spot\Entity
 {
     protected static $_datasource = 'test_types';
 
+    // Declared 'public static' here so they can be modified by tests - this is for TESTING ONLY
+    public static $_fields = array(
+        'id' => array('type' => 'int', 'primary' => true, 'serial' => true),
+        'serialized' => array('type' => 'serialized'),
+        'date_created' => array('type' => 'datetime')
+    );
+
     public static function fields()
     {
-        return array(
-            'id' => array('type' => 'int', 'primary' => true, 'serial' => true),
-            'serialized' => array('type' => 'serialized', 'required' => true),
-            'date_created' => array('type' => 'datetime')
-        );
+        return self::$_fields;
     }
 }
 

--- a/tests/Entity/Type.php
+++ b/tests/Entity/Type.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Types
+ * Exists solely for the purpose of testing custom types
+ *
+ * @package Spot
+ */
+class Entity_Type extends \Spot\Entity
+{
+    protected static $_datasource = 'test_types';
+
+    public static function fields()
+    {
+        return array(
+            'id' => array('type' => 'int', 'primary' => true, 'serial' => true),
+            'serialized' => array('type' => 'serialized', 'required' => true),
+            'date_created' => array('type' => 'datetime')
+        );
+    }
+}
+

--- a/tests/Test/Insert.php
+++ b/tests/Test/Insert.php
@@ -11,6 +11,7 @@ class Test_Insert extends PHPUnit_Framework_TestCase
         $mapper = test_spot_mapper();
         $mapper->migrate('Entity_Post');
         $mapper->migrate('Entity_Event');
+        $mapper->migrate('Entity_Type');
     }
 
     public function testInsertPostEntity()
@@ -159,6 +160,16 @@ class Test_Insert extends PHPUnit_Framework_TestCase
 
         $this->assertFalse($result);
         $this->assertEquals(array('Type contains invalid value'), $event->errors('type'));
+    }
+
+    public function testCreateTypeEntity()
+    {
+        $mapper = test_spot_mapper();
+        $data = array(
+            'serialized' => array('a' => 'b', 'foo' => 'bar')
+        );
+        $result = $mapper->create('Entity_Type', $data);
+        $this->assertTrue($result !== false);
     }
 }
 

--- a/tests/Test/Type/Json.php
+++ b/tests/Test/Type/Json.php
@@ -1,0 +1,20 @@
+<?php
+namespace Test\Type;
+use Spot\Type;
+
+class Json extends Type
+{
+    public static $_adapterType = 'text';
+
+    public static function load($value)
+    {
+        // Usually would 'json_decode' here, but we don't for testing (to ensure string has been json_encoded)
+        return $value;
+    }
+
+    public static function dump($value)
+    {
+        return json_encode($value);
+    }
+}
+


### PR DESCRIPTION
This is a fairly big update for the type system. It allows the type
classes themselves to set the column type that is used for table
migrations (creating and updating the tables) instead of relying solely
on a mapping in the adapters. This allows user-land custom types where
they were not possible before without adding an entry to the mappings
inside all the specific database adapters. Now users can register custom
type handlers and specify what actual column types they will use without
any further modifications to Spot. This is a big step in giving the type
system more control and power over how the type is stored.
- Add 'Text' type
- Add 'adapterOptions' method to allow Type class to set type and
  options array for adapter migrations (length, etc.)
- Add for custom serialized type that stores as TEXT
